### PR TITLE
More robust initial value parsing.

### DIFF
--- a/addon/components/mask-money.js
+++ b/addon/components/mask-money.js
@@ -27,7 +27,11 @@ export default Ember.TextField.extend({
     this.$().maskMoney(this.get('options'));
 
     if (this.get('number') !== undefined) {
-      var val = this.get('number').toString().replace(".", this.get('decimal'));
+      var val = this.get('number');
+      if (!(val instanceof Number)) {
+        val = Number(val);
+      }
+      val = val.toFixed(this.get('precision'));
       this.$().val(val);
       this.$().maskMoney('mask');
     }


### PR DESCRIPTION
Hi, look at that, I think that's better because I was having trouble for the initial precision of `number`:
if it was a `number` with just one decimal, like `585.0`, it was parsed as `58,50 €`, now It works fine!